### PR TITLE
return empty hash if the config file is empty

### DIFF
--- a/lib/glyptodont/configuration.rb
+++ b/lib/glyptodont/configuration.rb
@@ -21,7 +21,7 @@ module Glyptodont
 
     def config
       @config ||= if File.exist?(config_filename)
-                    YAML.load_file(config_filename)
+                    YAML.load_file(config_filename, fallback: {})
                   else
                     {}
                   end


### PR DESCRIPTION
`YAML.load_file` by default falls-back to returning `false` if the YAML file is "empty" (a file that parses but has no YAML in it is considered empty, too. E.g. a file with contents commented-out).

This PR provides the argument `fallback: {}` so that an empty hash is returned - which is the desired effect.
