### PR TITLE
report all old TODOs, use age of the youngest in message

### DIFF
--- a/lib/glyptodont/checkers/age.rb
+++ b/lib/glyptodont/checkers/age.rb
@@ -10,17 +10,17 @@ module Glyptodont
       end
 
       def check
-        @age, @reportable_todos = oldest_todos
+        @reportable_todos = oldest_todos
         message
       end
 
       def passed?
-        todos.empty? || age <= threshold
+        reportable_todos.empty?
       end
 
       private
 
-      attr_reader :todos, :threshold, :age, :reportable_todos
+      attr_reader :todos, :threshold, :reportable_todos
 
       def message
         if todos.empty?
@@ -28,14 +28,16 @@ module Glyptodont
         elsif passed?
           "At #{Glyptodont.pluralize(age, "day")}, TODOs are fresh enough for now"
         else
-          "Some TODOs are too stale at #{Glyptodont.pluralize(age, "day")} old:\n" +
+          age = reportable_todos.last[:age]
+          "Some TODOs are too stale at more than #{Glyptodont.pluralize(age - 1, "day")} old:\n" +
             reportable_todos.map { |t| Glyptodont.format_todo(t) }.join("\n")
         end
       end
 
       def oldest_todos
-        todos.group_by { |todo| todo[:age] }
-             .max_by { |age, _group| age }
+        todos.select { |todo| todo[:age] > threshold }
+             .sort_by { |todo| todo[:age] }
+             .reverse
       end
     end
   end

--- a/lib/glyptodont/checkers/age.rb
+++ b/lib/glyptodont/checkers/age.rb
@@ -26,10 +26,11 @@ module Glyptodont
         if todos.empty?
           "Nothing left to do"
         elsif passed?
-          "At #{Glyptodont.pluralize(age, "day")}, TODOs are fresh enough for now"
+          oldest = todos.max_by { |t| t[:age] }
+          "At #{Glyptodont.pluralize(oldest[:age], "day")}, TODOs are fresh enough for now"
         else
-          age = reportable_todos.last[:age]
-          "Some TODOs are too stale at more than #{Glyptodont.pluralize(age - 1, "day")} old:\n" +
+          youngest_stale = reportable_todos.last[:age]
+          "Some TODOs are too stale at more than #{Glyptodont.pluralize(youngest_stale - 1, "day")} old:\n" +
             reportable_todos.map { |t| Glyptodont.format_todo(t) }.join("\n")
         end
       end

--- a/spec/checkers/age_spec.rb
+++ b/spec/checkers/age_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe Glyptodont::Checkers::Age do
+  def todo(age)
+    {
+      file: "example.rb",
+      line: rand(1000),
+      text: "exmaple text",
+      name: "name",
+      time: Time.now - age * (24 * 60 * 60),
+      age: age
+    }
+  end
+
+  subject(:checker) { described_class.new(todos: todos, threshold: max_age) }
+
+  let(:todos) do
+    [
+      *todos_over_threshold,
+      todo(1),
+      todo(2),
+      todo(3),
+      todo(7)
+    ].shuffle
+  end
+
+  let(:todos_over_threshold) do
+    [
+      todo(11),
+      todo(14),
+      todo(15),
+      todo(17),
+      todo(300),
+      todo(18)
+    ].sort_by { |t| t[:age] }.reverse
+  end
+
+  let(:max_age) { 10 }
+
+  it "reports on all todos that exceed the threshold" do
+    expect(checker.check).to include(todos_over_threshold.map { |t| Glyptodont.format_todo(t) }.join("\n"))
+  end
+
+  it "reports the age of the youngest todo that exceeds the threshold" do
+    expect(checker.check).to include("Some TODOs are too stale at more than #{Glyptodont.pluralize(max_age, "day")} old:")
+  end
+end

--- a/spec/checkers/age_spec.rb
+++ b/spec/checkers/age_spec.rb
@@ -44,4 +44,19 @@ RSpec.describe Glyptodont::Checkers::Age do
   it "reports the age of the youngest todo that exceeds the threshold" do
     expect(checker.check).to include("Some TODOs are too stale at more than #{Glyptodont.pluralize(max_age, "day")} old:")
   end
+
+  context "when there are no todos older than the threshold" do
+    let(:todos) do
+      [
+        todo(1),
+        todo(2),
+        todo(3),
+        todo(7)
+      ].shuffle
+    end
+
+    it "reports things are fresh" do
+      expect(checker.check).to include("At 7 days, TODOs are fresh enough for now")
+    end
+  end
 end


### PR DESCRIPTION
Glyptodont would only report on the oldest TODOs that were the maximum age in days. This often going to be a single TODO while there may be many TODOs that exceed the threshold value.

This PR changes the way the threshold is checked, reports on all TODOs that exceed the threshold and uses the age of the _youngest_ TODO that exceeds the threshold in the messaging produced.
