### PR TITLE
Options in config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ gemspec
 gem "rake", "~> 13.0"
 
 gem "rspec", "~> 3.0"
+gem "rspec-its", "~> 1.3.0"
 
 gem "rubocop", "~> 1.7"

--- a/lib/glyptodont.rb
+++ b/lib/glyptodont.rb
@@ -10,6 +10,6 @@ require_relative "glyptodont/todo_researcher"
 
 module Glyptodont
   def self.check
-    Checker.new.check(ARGV)
+    Checker.new(ARGV).check
   end
 end

--- a/lib/glyptodont.rb
+++ b/lib/glyptodont.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "glyptodont/checker"
 require_relative "glyptodont/checkers/age"
 require_relative "glyptodont/checkers/counter"
 require_relative "glyptodont/configuration"
@@ -7,32 +8,8 @@ require_relative "glyptodont/formatting"
 require_relative "glyptodont/options"
 require_relative "glyptodont/todo_researcher"
 
-require "forwardable"
-
-# This is where the magic happens
 module Glyptodont
-  class << self
-    def check
-      @options = Options.new
-      @configuration = Configuration.new(directory)
-
-      todos = TodoResearcher.new(directory, ignore).research
-
-      checks = [
-        Checkers::Counter.new(todos: todos, threshold: threshold),
-        Checkers::Age.new(todos: todos, threshold: max_age_in_days)
-      ].freeze
-
-      checks.each { |check| puts check.check }
-
-      checks.all?(&:passed?)
-    end
-
-    attr_reader :configuration, :options
-
-    extend Forwardable
-
-    def_delegator :@configuration, :ignore
-    def_delegators :@options, :directory, :threshold, :max_age_in_days
+  def self.check
+    Checker.new.check(ARGV)
   end
 end

--- a/lib/glyptodont/checker.rb
+++ b/lib/glyptodont/checker.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+module Glyptodont
+  # This is where the magic happens
+  class Checker
+    def initialize(args)
+      @options = Options.new(args)
+      @configuration = Configuration.new(directory)
+    end
+
+    def check
+      todos = TodoResearcher.new(directory, ignore).research
+
+      checks = [
+        Checkers::Counter.new(todos: todos, threshold: threshold),
+        Checkers::Age.new(todos: todos, threshold: max_age_in_days)
+      ].freeze
+
+      checks.each { |check| puts check.check }
+
+      checks.all?(&:passed?)
+    end
+
+    attr_reader :configuration, :options
+
+    extend Forwardable
+
+    def_delegator :@configuration, :ignore
+    def_delegators :@options, :directory
+
+    def threshold
+      options.threshold || configuration.threshold
+    end
+
+    def max_age_in_days
+      options.max_age_in_days || configuration.max_age_in_days
+    end
+  end
+end

--- a/lib/glyptodont/configuration.rb
+++ b/lib/glyptodont/configuration.rb
@@ -7,12 +7,23 @@ module Glyptodont
   # Allow for configuring the tool
   class Configuration
     FILENAME = ".glyptodont.yaml"
+    DEFAULT_THRESHOLD = 10
+    DEFAULT_MAX_AGE_IN_DAYS = 14
+
     def initialize(directory)
       @config_filename = File.join(directory, FILENAME)
     end
 
     def ignore
       @ignore ||= extract_ignore_set || []
+    end
+
+    def threshold
+      @threshold ||= config.fetch("threshold", DEFAULT_THRESHOLD)
+    end
+
+    def max_age_in_days
+      @max_age_in_days ||= config.fetch("max_age_in_days", DEFAULT_MAX_AGE_IN_DAYS)
     end
 
     private

--- a/lib/glyptodont/options.rb
+++ b/lib/glyptodont/options.rb
@@ -9,10 +9,9 @@ module Glyptodont
   class Options
     attr_reader :directory, :threshold, :max_age_in_days
 
-    def initialize
+    def initialize(args)
+      @args = args
       @directory = "."
-      @threshold = 10
-      @max_age_in_days = 14
       parse
     end
 
@@ -26,7 +25,7 @@ module Glyptodont
         threshold_option(opts)
         max_age_in_days_option(opts)
         version_option(opts)
-      end.parse!(ARGV)
+      end.parse!(@args)
     end
 
     def directory_option(opts)

--- a/spec/checker_spec.rb
+++ b/spec/checker_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe Glyptodont::Checker do
+  context "configuration" do
+    subject(:checker) { described_class.new(args) }
+
+    let(:args) { [] }
+
+    context "defaults" do
+
+      its(:threshold) { is_expected.to eq 10}
+      its(:max_age_in_days) { is_expected.to eq 14}
+    end
+
+    context "values in options" do
+      let(:args) do
+        [
+          "--threshold", "2",
+          "--max-age", "99"
+        ]
+      end
+
+      its(:threshold) { is_expected.to eq 2 }
+      its(:max_age_in_days) { is_expected.to eq 99 }
+    end
+
+    context "values in config" do
+      let(:args) do
+        [
+          "--directory", Pathname(__dir__).join("fixtures/config").to_s
+        ]
+      end
+
+      its(:threshold) { is_expected.to eq 77 }
+      its(:max_age_in_days) { is_expected.to eq 1111 }
+    end
+
+    context "values in both" do
+      let(:args) do
+        [
+          "--directory", Pathname(__dir__).join("fixtures/config").to_s,
+          "--threshold", "123",
+          "--max-age", "987"
+        ]
+      end
+
+      its(:threshold) { is_expected.to eq 123 }
+      its(:max_age_in_days) { is_expected.to eq 987 }
+    end
+  end
+end

--- a/spec/fixtures/config/.glyptodont.yaml
+++ b/spec/fixtures/config/.glyptodont.yaml
@@ -1,0 +1,2 @@
+threshold: 77
+max_age_in_days: 1111

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'rspec/its'
 require "glyptodont"
 
 RSpec.configure do |config|


### PR DESCRIPTION
I like the idea of having the config for a directory being able to provide "better defaults" for the tool, rather than always having that bound to the command-line invocation.

This allows for contextually "sensible" results when invoking glyptodont in a directory.

The changes here are bigger than I would have liked (extracting the Checker class) but I think that was neater than trying to graft the logic into the Glyptodont module directly (especially when trying to make the changes testable).
