### PR TITLE
Support for Ruby 2.5 and above

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 2.4.0
+  TargetRubyVersion: 2.5
 
 Style/StringLiterals:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,5 @@
 AllCops:
   NewCops: enable
-  SuggestExtensions: false
   TargetRubyVersion: 2.5
 
 Style/StringLiterals:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Dropped support for Ruby version older than 2.5 [[#4]]
+
+[#4]: https://github.com/johnsyweb/glyptodont/pull/4
 [Unreleased]: https://github.com/johnsyweb/glyptodont/compare/v0.2.0..main
 
 ## [0.2.0] - 2021-03-28

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,13 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in glyptodont.gemspec
 gemspec
 
-gem "rake", "~> 13.0"
-
-gem "rspec", "~> 3.0"
-gem "rspec-its", "~> 1.3.0"
-
-gem "rubocop", "~> 1.7"
+group :developement, :test do
+  gem "rake"
+  gem "rspec"
+  gem "rspec-its"
+  gem "rubocop"
+  gem "rubocop-rake"
+  gem "rubocop-rspec"
+end

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ ignore:
 
 ## Requirements
 
-- Ruby (tested against v2.4 and above)
+- Ruby (tested against v2.5 and above)
 - Git
 - CMake
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Glyptodont
 
-Use this gem if you have ever deployed code to production without doing all of
-your to-dos.
+Use this gem if you want to avoid deploying code to production without doing all
+of your to-dos.
 
 ## Introduction
 

--- a/glyptodont.gemspec
+++ b/glyptodont.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Use this gem if you have ever deployed code to production without doing all of your to-dos"
   spec.homepage      = GITHUB_URL
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = GITHUB_URL

--- a/glyptodont.gemspec
+++ b/glyptodont.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["paj+github@johnsy.com"]
 
   spec.summary       = "A bit like `git grep 'T0D0'`, but better."  # .tr("0", "O")
-  spec.description   = "Use this gem if you have ever deployed code to production without doing all of your to-dos"
+  spec.description   = "Use this gem if you want to avoid deploying code to production without doing all of your to-dos"
   spec.homepage      = GITHUB_URL
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5")

--- a/glyptodont.gemspec
+++ b/glyptodont.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = GITHUB_URL
   spec.metadata["changelog_uri"] = "#{GITHUB_URL}blob/HEAD/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }

--- a/spec/checkers/age_spec.rb
+++ b/spec/checkers/age_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Glyptodont::Checkers::Age do
       line: rand(1000),
       text: "exmaple text",
       name: "name",
-      time: Time.now - age * (24 * 60 * 60),
+      time: Time.now - (age * (24 * 60 * 60)),
       age: age
     }
   end


### PR DESCRIPTION
- Support Ruby 2.5 through 3.1
- Add Rubocop plugins
- Improve gem description
- Gemspec/RequireMFA
- Lint/AmbiguousOperatorPrecedence
